### PR TITLE
fix host name at the reverse proxy by explicilty setting hostname bot…

### DIFF
--- a/main.go
+++ b/main.go
@@ -11,7 +11,6 @@ import (
 	"net/url"
 	"os"
 	"os/signal"
-	"strings"
 	"syscall"
 	"time"
 
@@ -237,34 +236,4 @@ func main() {
 	if err := g.Run(); err != nil {
 		stdlog.Fatal(err)
 	}
-}
-
-func singleJoiningSlash(a, b string) string {
-	aslash := strings.HasSuffix(a, "/")
-	bslash := strings.HasPrefix(b, "/")
-	switch {
-	case aslash && bslash:
-		return a + b[1:]
-	case !aslash && !bslash:
-		return a + "/" + b
-	}
-	return a + b
-}
-func joinURLPath(a, b *url.URL) (path, rawpath string) {
-	if a.RawPath == "" && b.RawPath == "" {
-		return singleJoiningSlash(a.Path, b.Path), ""
-	}
-	// Same as singleJoiningSlash, but uses EscapedPath to determine
-	// whether a slash should be added
-	apath := a.EscapedPath()
-	bpath := b.EscapedPath()
-	aslash := strings.HasSuffix(apath, "/")
-	bslash := strings.HasPrefix(bpath, "/")
-	switch {
-	case aslash && bslash:
-		return a.Path + b.Path[1:], apath + bpath[1:]
-	case !aslash && !bslash:
-		return a.Path + "/" + b.Path, apath + "/" + bpath
-	}
-	return a.Path + b.Path, apath + bpath
 }


### PR DESCRIPTION
At ReverseProxy, HTTP Header value for Host is not set properly (instead contains the hostname of the token-refresher). 
With this problem, The local tests would pass as both the source and host to proxy are both 'localhost'. 
This problem can be reproduced when the host to proxy to is different from the the host the token-refresher runs.
This fix require explicitly setting the hostname as part of HttpRequest at the ReverseProxy.

Checkout reference to this problem [here](https://github.com/golang/go/issues/28168)