### PR TITLE
OSD-7065: Conditional container push

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
       - checkout
       - run: |
           echo "$DOCKER_PASS" | docker login quay.io --username $DOCKER_USER --password-stdin
-          make container-push
+          make conditional-container-push
 
   container-release:
     machine:

--- a/Makefile
+++ b/Makefile
@@ -92,6 +92,10 @@ container-push: container
 	docker push $(DOCKER_REPO):$(VCS_BRANCH)-$(BUILD_DATE)-$(VERSION)
 	docker push $(DOCKER_REPO):latest
 
+.PHONY: conditional-container-push
+conditional-container-push:
+	build/conditional-container-push.sh $(DOCKER_REPO):$(VCS_BRANCH)-$(BUILD_DATE)-$(VERSION)
+
 .PHONY: container-release
 container-release: VERSION_TAG = $(strip $(shell [ -d .git ] && git tag --points-at HEAD))
 container-release: container

--- a/build/conditional-container-push.sh
+++ b/build/conditional-container-push.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+
+usage() {
+    echo "Usage: $0 IMAGE_URI" >&2
+    exit 1
+}
+
+## image_exists_in_repo IMAGE_URI
+#
+# Checks whether IMAGE_URI -- e.g. quay.io/app-sre/osd-metrics-exporter:abcd123
+# -- exists in the remote repository.
+# If so, returns success.
+# If the image does not exist, but the query was otherwise successful, returns
+# failure.
+# If the query fails for any reason, prints an error and *exits* nonzero.
+#
+# This function cribbed from:
+# https://github.com/openshift/boilerplate/blob/d2d6640ef28a7ce54ac639db32c825aa4bb492a0/boilerplate/_lib/common.sh#L77-L125
+image_exists_in_repo() {
+    local image_uri=$1
+    local output
+
+    if output=$(skopeo inspect docker://"${image_uri}" 2>&1); then
+        # The image exists. Sanity check the output.
+        local digest
+        digest=$(jq -r .Digest <<< "$output")
+        if [[ -z "$digest" ]]; then
+            echo "Unexpected error: skopeo inspect succeeded, but output contained no .Digest"
+            echo "Here's the output:"
+            echo "$output"
+            exit 1
+        fi
+        echo "Image ${image_uri} exists with digest $digest."
+        return 0
+    elif [[ "$output" == *"manifest unknown"* ]]; then
+        # We were able to talk to the repository, but the tag doesn't exist.
+        # This is the normal "green field" case.
+        echo "Image ${image_uri} does not exist in the repository."
+        return 1
+    elif [[ "$output" == *"was deleted or has expired"* ]]; then
+        # This should be rare, but accounts for cases where we had to
+        # manually delete an image.
+        echo "Image ${image_uri} was deleted from the repository."
+        echo "Proceeding as if it never existed."
+        return 1
+    else
+        # Any other error. For example:
+        #   - "unauthorized: access to the requested resource is not
+        #     authorized". This happens not just on auth errors, but if we
+        #     reference a repository that doesn't exist.
+        #   - "no such host".
+        #   - Network or other infrastructure failures.
+        # In all these cases, we want to bail, because we don't know whether
+        # the image exists (and we'd likely fail to push it anyway).
+        echo "Error querying the repository for ${image_uri}:"
+        echo "$output"
+        exit 1
+    fi
+}
+
+set -exv
+
+IMAGE_URI=$1
+[[ -z "$IMAGE_URI" ]] && usage
+
+# NOTE(efried): Since we reference images by digest, rebuilding an image
+# with the same tag can be Bad. This is because the digest calculation
+# includes metadata such as date stamp, meaning that even though the
+# contents may be identical, the digest may change. In this situation,
+# the original digest URI no longer has any tags referring to it, so the
+# repository deletes it. This can break existing deployments referring
+# to the old digest. We could have solved this issue by generating a
+# permanent tag tied to each digest. We decided to do it this way
+# instead.
+# For testing purposes, if you need to force the build/push to rerun,
+# delete the image at $IMAGE_URI.
+if image_exists_in_repo "$IMAGE_URI"; then
+    echo "Image ${IMAGE_URI} already exists. Nothing to do!"
+    exit 0
+fi
+
+make container-push


### PR DESCRIPTION
To facilitate referencing token-refresher containers by digest rather than by tag, we need to address the "disappearing digest" problem (see the linked card for background).

This commit accomplishes this by:
- Adding a make target and shell script that wraps the existing `container-make` in a conditional, short-circuiting if the image already exists in the repository.
- Configuring Circle CI's `container-push` target to invoke the above rather than `container-make` directly.

TODO: We could be more efficient by also conditioning the `build` job.

https://issues.redhat.com/browse/OSD-7065