### PR TITLE
Add prefix header with value '/' to forwarded requests

### DIFF
--- a/main.go
+++ b/main.go
@@ -30,6 +30,7 @@ import (
 
 const (
 	retryInterval = 5 * time.Second
+	prefixHeader  = "X-Forwarded-Prefix"
 )
 
 type config struct {
@@ -234,6 +235,9 @@ func main() {
 					request.URL.Host = cfg.url.Host
 					// Derive path from the paths of configured URL and request URL.
 					request.URL.Path, request.URL.RawPath = joinURLPath(cfg.url, request.URL)
+					// Add prefix header with value "/", since from a client's perspective
+					// we are forwarding /<anything> to /<cfg.url.Path>/<anything>.
+					request.Header.Add(prefixHeader, "/")
 				},
 			}
 			p.Transport = &oauth2.Transport{


### PR DESCRIPTION
Since we are transparently forwarding requests from `/<anything>` to `/<cfg.url.Path>/<anything>`, it'll be helpful to pass `X-Forwarded-Prefix: /` as a hint to upstream.