### PR TITLE
fix(dockerfile): reduce attack surface

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /opt
 
 RUN git update-index --refresh; make token-refresher
 
-FROM alpine:3.10 as runner
+FROM scratch as runner
 
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /opt/token-refresher /bin/token-refresher


### PR DESCRIPTION
a scan was conducted that showed vulns in the resulting container
as I tested this locally
```
$ docker build -t test .
$ docker run --rm -it test
REDACTED_DATE one of --file or --url is required
```

and it seems the container works correctly, I suggest we use this
hardened tag

further tests can come and i'll test them aswell
