### PR TITLE
Add multi arch image build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,14 +44,14 @@ jobs:
           echo "$DOCKER_PASS" | docker login quay.io --username $DOCKER_USER --password-stdin
           make conditional-container-build-push
 
-  container-release-push:
+  container-release-build-push:
     machine:
       image: ubuntu-2004:current
     steps:
       - checkout
       - run: |
           echo "$DOCKER_PASS" | docker login quay.io --username $DOCKER_USER --password-stdin
-          make container-release-push
+          make container-release-build-push
 
 workflows:
   version: 2
@@ -70,7 +70,7 @@ workflows:
                 - master
   tagged-master:
     jobs:
-      - container-release-push:
+      - container-release-build-push:
           filters:
             tags:
               # Suggested SemVer regex:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,23 +35,23 @@ jobs:
       - run: make manifests
       - run: git diff --exit-code -- .
 
-  container-push:
+  container-nightly-push:
     machine:
-      image: ubuntu-1604:201903-01
+      image: ubuntu-2004:current
     steps:
       - checkout
       - run: |
           echo "$DOCKER_PASS" | docker login quay.io --username $DOCKER_USER --password-stdin
-          make conditional-container-push
+          make conditional-container-nightly-push
 
-  container-release:
+  container-release-push:
     machine:
-      image: ubuntu-1604:201903-01
+      image: ubuntu-2004:current
     steps:
       - checkout
       - run: |
           echo "$DOCKER_PASS" | docker login quay.io --username $DOCKER_USER --password-stdin
-          make container-release
+          make container-release-push
 
 workflows:
   version: 2
@@ -61,7 +61,7 @@ workflows:
       - lint
       - test
       - build-jsonnet
-      - container-push:
+      - container-nightly-push:
           requires:
             - build
           filters:
@@ -70,7 +70,7 @@ workflows:
                 - master
   tagged-master:
     jobs:
-      - container-release:
+      - container-release-push:
           filters:
             tags:
               # Suggested SemVer regex:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,14 +35,14 @@ jobs:
       - run: make manifests
       - run: git diff --exit-code -- .
 
-  container-nightly-push:
+  container-build-push:
     machine:
       image: ubuntu-2004:current
     steps:
       - checkout
       - run: |
           echo "$DOCKER_PASS" | docker login quay.io --username $DOCKER_USER --password-stdin
-          make conditional-container-nightly-push
+          make conditional-container-build-push
 
   container-release-push:
     machine:
@@ -61,7 +61,7 @@ workflows:
       - lint
       - test
       - build-jsonnet
-      - container-nightly-push:
+      - container-build-push:
           requires:
             - build
           filters:

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,13 @@
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
+# macOS junk
+.DS_Store
+
+# VSCode stuff
+.vscode/
+
+# Project specific
 token-refresher
 token
 tmp/

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@
 token-refresher
 token
 tmp/
+.buildxcache/

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN apk add --update --no-cache ca-certificates tzdata git make bash && update-c
 
 ADD . /opt
 WORKDIR /opt
-# Run this before `make token-refresher` to be friendy with Docker image layer cache
+# Run this before `make token-refresher` to be friendy with Docker image layer cache.
 RUN make vendor
 
 ARG TARGETOS TARGETARCH

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,13 @@
-FROM golang:1.14.1-alpine3.11 as builder
+FROM --platform=$BUILDPLATFORM golang:1.14.1-alpine3.11 as builder
 
 RUN apk add --update --no-cache ca-certificates tzdata git make bash && update-ca-certificates
 
 ADD . /opt
 WORKDIR /opt
 
-RUN git update-index --refresh; make token-refresher
+ARG TARGETOS TARGETARCH
+
+RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} make token-refresher
 
 FROM scratch as runner
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@ RUN apk add --update --no-cache ca-certificates tzdata git make bash && update-c
 
 ADD . /opt
 WORKDIR /opt
+# Run this before `make token-refresher` to be friendy with Docker image layer cache
+RUN make vendor
 
 ARG TARGETOS TARGETARCH
 

--- a/Makefile
+++ b/Makefile
@@ -121,9 +121,9 @@ container-build-push:
 conditional-container-build-push:
 	build/conditional-container-push.sh $(DOCKER_REPO):$(VCS_BRANCH)-$(BUILD_DATE)-$(VERSION)
 
-.PHONY: container-release-push
-container-release-push: VERSION_TAG = $(strip $(shell [ -d .git ] && git tag --points-at HEAD))
-container-release-push: container-nightly-push
+.PHONY: container-release-build-push
+container-release-build-push: VERSION_TAG = $(strip $(shell [ -d .git ] && git tag --points-at HEAD))
+container-release-build-push: container-build-push
 	# https://git-scm.com/docs/git-tag#Documentation/git-tag.txt---points-atltobjectgt
 	@docker buildx build \
 		--push \

--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,7 @@ container-release-push: VERSION_TAG = $(strip $(shell [ -d .git ] && git tag --p
 container-release-push: container-nightly-push
 	# https://git-scm.com/docs/git-tag#Documentation/git-tag.txt---points-atltobjectgt
 	@docker buildx build \
-		--output type=oci,dest=oci.tar \
+		--push \
 		--platform linux/amd64,linux/arm64 \
 		--cache-from type=local,src=./.buildxcache/ \
 	    --build-arg BUILD_DATE="$(BUILD_TIMESTAMP)" \

--- a/Makefile
+++ b/Makefile
@@ -101,8 +101,8 @@ container-dev:
 		.
 	docker tag $(DOCKER_REPO):$(VCS_BRANCH)-$(BUILD_DATE)-$(VERSION) $(DOCKER_REPO):latest
 
-.PHONY: container-nightly-push
-container-nightly-push:
+.PHONY: container-build-push
+container-build-push:
 	git update-index --refresh
 	@docker buildx build \
 		--push \
@@ -117,8 +117,8 @@ container-nightly-push:
 		-t $(DOCKER_REPO):latest \
 		.
 
-.PHONY: conditional-container-nightly-push
-conditional-container-nightly-push:
+.PHONY: conditional-container-build-push
+conditional-container-build-push:
 	build/conditional-container-push.sh $(DOCKER_REPO):$(VCS_BRANCH)-$(BUILD_DATE)-$(VERSION)
 
 .PHONY: container-release-push

--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,7 @@ container-dev:
 
 .PHONY: container-nightly-push
 container-nightly-push:
-	# git update-index --refresh
+	git update-index --refresh
 	@docker buildx build \
 		--push \
 		--platform linux/amd64,linux/arm64 \

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ LIB_DIR ?= $(TMP_DIR)/lib
 FIRST_GOPATH := $(firstword $(subst :, ,$(shell go env GOPATH)))
 OS ?= $(shell uname -s | tr '[A-Z]' '[a-z]')
 ARCH ?= $(shell uname -m)
+GOARCH ?= $(shell go env GOARCH)
 
 VERSION := $(strip $(shell [ -d .git ] && git describe --always --tags --dirty))
 BUILD_DATE := $(shell date -u +"%Y-%m-%d")
@@ -36,7 +37,7 @@ README.md: $(EMBEDMD) tmp/help.txt
 	$(EMBEDMD) -w README.md
 
 token-refresher: vendor main.go $(wildcard *.go) $(wildcard */*.go)
-	CGO_ENABLED=0 GOOS=$(OS) GOARCH=amd64 GO111MODULE=on GOPROXY=https://proxy.golang.org go build -mod vendor -a -ldflags '-s -w' -o $@ .
+	CGO_ENABLED=0 GOOS=$(OS) GOARCH=$(GOARCH) GO111MODULE=on GOPROXY=https://proxy.golang.org go build -mod vendor -a -ldflags '-s -w' -o $@ .
 
 .PHONY: build
 build: token-refresher
@@ -88,32 +89,54 @@ jsonnet/example/manifests: jsonnet/example/main.jsonnet $(JSONNET) $(GOJSONTOYAM
 	$(JSONNET) -m jsonnet/example/manifests jsonnet/example/main.jsonnet | xargs -I{} sh -c 'cat {} | $(GOJSONTOYAML) > {}.yaml' -- {}
 	find jsonnet/example/manifests -type f ! -name '*.yaml' -delete
 
-.PHONY: container
-container: Dockerfile
-	@docker build --build-arg BUILD_DATE="$(BUILD_TIMESTAMP)" \
+.PHONY: container-dev
+container-dev:
+	@docker build \
+	    --build-arg BUILD_DATE="$(BUILD_TIMESTAMP)" \
 		--build-arg VERSION="$(VERSION)" \
 		--build-arg VCS_REF="$(VCS_REF)" \
 		--build-arg VCS_BRANCH="$(VCS_BRANCH)" \
 		--build-arg DOCKERFILE_PATH="/Dockerfile" \
-		-t $(DOCKER_REPO):$(VCS_BRANCH)-$(BUILD_DATE)-$(VERSION) .
-	@docker tag $(DOCKER_REPO):$(VCS_BRANCH)-$(BUILD_DATE)-$(VERSION) $(DOCKER_REPO):latest
+		-t $(DOCKER_REPO):$(VCS_BRANCH)-$(BUILD_DATE)-$(VERSION) \
+		.
+	docker tag $(DOCKER_REPO):$(VCS_BRANCH)-$(BUILD_DATE)-$(VERSION) $(DOCKER_REPO):latest
 
-.PHONY: container-push
-container-push: container
-	docker push $(DOCKER_REPO):$(VCS_BRANCH)-$(BUILD_DATE)-$(VERSION)
-	docker push $(DOCKER_REPO):latest
+.PHONY: container-nightly-push
+container-nightly-push:
+	# git update-index --refresh
+	@docker buildx build \
+		--push \
+		--platform linux/amd64,linux/arm64 \
+		--cache-to type=local,dest=./.buildxcache/ \
+	    --build-arg BUILD_DATE="$(BUILD_TIMESTAMP)" \
+		--build-arg VERSION="$(VERSION)" \
+		--build-arg VCS_REF="$(VCS_REF)" \
+		--build-arg VCS_BRANCH="$(VCS_BRANCH)" \
+		--build-arg DOCKERFILE_PATH="/Dockerfile" \
+		-t $(DOCKER_REPO):$(VCS_BRANCH)-$(BUILD_DATE)-$(VERSION) \
+		-t $(DOCKER_REPO):latest \
+		.
 
-.PHONY: conditional-container-push
-conditional-container-push:
+.PHONY: conditional-container-nightly-push
+conditional-container-nightly-push:
 	build/conditional-container-push.sh $(DOCKER_REPO):$(VCS_BRANCH)-$(BUILD_DATE)-$(VERSION)
 
-.PHONY: container-release
-container-release: VERSION_TAG = $(strip $(shell [ -d .git ] && git tag --points-at HEAD))
-container-release: container
+.PHONY: container-release-push
+container-release-push: VERSION_TAG = $(strip $(shell [ -d .git ] && git tag --points-at HEAD))
+container-release-push: container-nightly-push
 	# https://git-scm.com/docs/git-tag#Documentation/git-tag.txt---points-atltobjectgt
-	@docker tag $(DOCKER_REPO):$(VCS_BRANCH)-$(BUILD_DATE)-$(VERSION) $(DOCKER_REPO):$(VERSION_TAG)
-	docker push $(DOCKER_REPO):$(VERSION_TAG)
-	docker push $(DOCKER_REPO):latest
+	@docker buildx build \
+		--output type=oci,dest=oci.tar \
+		--platform linux/amd64,linux/arm64 \
+		--cache-from type=local,src=./.buildxcache/ \
+	    --build-arg BUILD_DATE="$(BUILD_TIMESTAMP)" \
+		--build-arg VERSION="$(VERSION)" \
+		--build-arg VCS_REF="$(VCS_REF)" \
+		--build-arg VCS_BRANCH="$(VCS_BRANCH)" \
+		--build-arg DOCKERFILE_PATH="/Dockerfile" \
+		-t $(DOCKER_REPO):$(VERSION_TAG) \
+		-t $(DOCKER_REPO):latest \
+		.
 
 .PHONY: integration-test-dependencies
 integration-test-dependencies: $(THANOS) $(UP) $(HYDRA) $(OBSERVATORIUM)

--- a/build/conditional-container-push.sh
+++ b/build/conditional-container-push.sh
@@ -99,4 +99,4 @@ if image_exists_in_repo "$IMAGE_URI"; then
     exit 0
 fi
 
-make container-push
+make container-nightly-push

--- a/build/conditional-container-push.sh
+++ b/build/conditional-container-push.sh
@@ -99,4 +99,4 @@ if image_exists_in_repo "$IMAGE_URI"; then
     exit 0
 fi
 
-make container-nightly-push
+make container-build-push


### PR DESCRIPTION
## What was done

Multi arch build is working as follows:

1. The project is cross compiled running in the `builder` stage, running in the same architecture as the host. No emulation happens here. This happens thanks to the `--platform=$BUILDPLATFORM` configuration in the `FROM` clause, courtesy of `buildx`. `TARGETOS` and `TARGETARCH` args are automatically sent by `buildx` based on the platforms given to the `buildx` cli arg `--platform`.
2. The `runner` stage is then built with emulation and just copies over the binary from the previous stage. Because we don't pass a `--platform` option to the `FROM` clause there, it's built in the `TARGETPLATFORM`.

## Why was it done?

To better support contributors or end-users working using ARM64 processors, i.e. Macbooks with Apple Silicon, Graviton instances in AWS, M1 instances in Google Cloud, etc. 

## What was changed

- Renamed a few makefile targets to avoid confusion between nightly builds (pushed on every commit) and release builds (pushed when a tag is created).
- Added a `make container-dev` target that builds the container without using the multi-arch toolchain.
- Updated Circle CI images.

## Tests

Here are some test images that I published:

<img width="1844" alt="Screenshot 2022-07-22 at 15 39 06" src="https://user-images.githubusercontent.com/159076/180451746-893b9111-dd77-414b-8e2f-c296a4808fd8.png">

Aaaand here it is running natively on my ARM64 macOS: 

![image](https://user-images.githubusercontent.com/159076/180451884-ea72985f-01b6-4735-a093-8df040182bae.png)

