### PR TITLE
Create buildx runner before building containers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,6 +42,7 @@ jobs:
       - checkout
       - run: |
           echo "$DOCKER_PASS" | docker login quay.io --username $DOCKER_USER --password-stdin
+          docker buildx create --use
           make conditional-container-build-push
 
   container-release-build-push:
@@ -51,6 +52,7 @@ jobs:
       - checkout
       - run: |
           echo "$DOCKER_PASS" | docker login quay.io --username $DOCKER_USER --password-stdin
+          docker buildx create --use
           make container-release-build-push
 
 workflows:


### PR DESCRIPTION
Signed-off-by: Douglas Camata <159076+douglascamata@users.noreply.github.com>

This should fix [the build error](https://app.circleci.com/pipelines/github/observatorium/token-refresher/58/workflows/20dc8fdf-5b45-42b4-860e-5107aaa298ff/jobs/219) seen after after #20 was merged by creating a builder with the `docker-container` driver (default when you create new builders). 

This driver is able to handle the `cache-to` and `cache-from` options, intended to create a cache from the build steps of `make container-build-push` to be used on on `make container-release-build-push`.

