### PR TITLE
Improve setup-go Github Action usage & remove it where it's not needed

### DIFF
--- a/.github/env
+++ b/.github/env
@@ -1,0 +1,1 @@
+golang-version=1.18.x

--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -15,19 +15,6 @@ jobs:
       - name: Checkout code into the Go module directory.
         uses: actions/checkout@v3
 
-      - name: Install Go
-        uses: actions/setup-go@v3
-        with:
-          go-version: 1.14.x
-
-      - name: Cache for Go modules
-        uses: actions/cache@v3
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-
       - name: Login to Quay.io
         uses: docker/login-action@v2
         with:

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -33,14 +33,6 @@ jobs:
       - name: Checkout code into the Go module directory.
         uses: actions/checkout@v3
 
-      - name: Import environment variables from file
-        run: cat ".github/env" >> $GITHUB_ENV
-
-      - name: Install Go
-        uses: actions/setup-go@v3
-        with:
-          go-version: '${{ env.golang-version }}'
-
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v2

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -14,17 +14,14 @@ jobs:
       - name: Checkout code into the Go module directory.
         uses: actions/checkout@v3
 
+      - name: Import environment variables from file
+        run: cat ".github/env" >> $GITHUB_ENV
+
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18.x
-
-      - uses: actions/cache@v3
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+          go-version: '${{ env.golang-version }}'
+          cache: true
 
       - name: Run source code linting.
         run: make lint
@@ -36,10 +33,13 @@ jobs:
       - name: Checkout code into the Go module directory.
         uses: actions/checkout@v3
 
+      - name: Import environment variables from file
+        run: cat ".github/env" >> $GITHUB_ENV
+
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18.x
+          go-version: '${{ env.golang-version }}'
 
       - name: Set up Docker Buildx
         id: buildx
@@ -63,17 +63,14 @@ jobs:
       - name: Checkout code into the Go module directory.
         uses: actions/checkout@v3
 
+      - name: Import environment variables from file
+        run: cat ".github/env" >> $GITHUB_ENV
+
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18.x
-
-      - uses: actions/cache@v3
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+          go-version: '${{ env.golang-version }}'
+          cache: true
 
       - name: Build the Go binary.
         run: make token-refresher
@@ -91,17 +88,14 @@ jobs:
       - name: Checkout code into the Go module directory.
         uses: actions/checkout@v3
 
+      - name: Import environment variables from file
+        run: cat ".github/env" >> $GITHUB_ENV
+
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18.x
-
-      - uses: actions/cache@v3
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+          go-version: '${{ env.golang-version }}'
+          cache: true
 
       - name: Run source code linting.
         run: make manifests

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.14.1-alpine3.11 as builder
+FROM --platform=$BUILDPLATFORM golang:1.18-alpine3.16 as builder
 
 RUN apk add --update --no-cache ca-certificates tzdata git make bash && update-ca-certificates
 


### PR DESCRIPTION
* Use an `env` file to keep the Golang version. This helps avoiding to have to change the Go version in many different actions used by all workflows of the project.
* Use the cache feature that is included in the `setup-go` action. Helps cleaning up a bit and delegating the caching responsibility. 
* Update the builder container Go version to v1.18, matching the version used for running tests and linting.
* Removed the `setup-go` action from container building workflows. These use the builder container's Go to compile the project.