### PR TITLE
Allow "scope" to be set in the token

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@
 # VSCode stuff
 .vscode/
 
+#JetBrains stuff
+.idea/
+
 # Project specific
 token-refresher
 token

--- a/main.go
+++ b/main.go
@@ -46,7 +46,7 @@ type config struct {
 	oidc     oidcConfig
 	server   serverConfig
 	upstream upstreamConfig
-	scope    string
+	scope    []string
 }
 
 type upstreamConfig struct {
@@ -83,7 +83,7 @@ func parseFlags() (*config, error) {
 	flag.StringVar(&cfg.oidc.audience, "oidc.audience", "", "The audience for whom the access token is intended, see https://openid.net/specs/openid-connect-core-1_0.html#IDToken.")
 	flag.StringVar(&cfg.oidc.username, "oidc.username", "", "The username to use for OIDC authentication. If both username and password are set then grant_type is set to password.")
 	flag.StringVar(&cfg.oidc.password, "oidc.password", "", "The password to use for OIDC authentication. If both username and password are set then grant_type is set to password.")
-	flag.StringVar(&cfg.scope, "scope", "", "The scope to be included in the payload data of the token.")
+	flag.StringSliceVar(&cfg.scope, "scope", []string{""}, "The scope to be included in the payload data of the token.  Scopes can either be comma-separated or space-separated.")
 	flag.StringVar(&cfg.file, "file", "", "The path to the file in which to write the retrieved token.")
 	flag.StringVar(&cfg.tempFile, "temp-file", "", "The path to a temporary file to use for atomically update the token file. If left empty, \".tmp\" will be suffixed to the token file.")
 	rawURL := flag.String("url", "", "The target URL to which to proxy requests. All requests will have the acces token in the Authorization HTTP header.(DEPRECATED: Use -upstream.url instead)")
@@ -228,9 +228,9 @@ func main() {
 				"grant_type": []string{"password"},
 			}
 		}
-		if cfg.scope != "" {
+		if len(cfg.scope) != 0 {
 			ccc.EndpointParams = url.Values{
-				"scope": []string{cfg.scope},
+				"scope": []string{strings.Join(cfg.scope, " ")},
 			}
 		}
 		if cfg.file != "" {

--- a/main.go
+++ b/main.go
@@ -83,7 +83,7 @@ func parseFlags() (*config, error) {
 	flag.StringVar(&cfg.oidc.audience, "oidc.audience", "", "The audience for whom the access token is intended, see https://openid.net/specs/openid-connect-core-1_0.html#IDToken.")
 	flag.StringVar(&cfg.oidc.username, "oidc.username", "", "The username to use for OIDC authentication. If both username and password are set then grant_type is set to password.")
 	flag.StringVar(&cfg.oidc.password, "oidc.password", "", "The password to use for OIDC authentication. If both username and password are set then grant_type is set to password.")
-	flag.StringSliceVar(&cfg.scope, "scope", []string{""}, "The scope to be included in the payload data of the token.  Scopes can either be comma-separated or space-separated.")
+	flag.StringSliceVar(&cfg.scope, "scope", []string{""}, "The scope to be included in the payload data of the token. Scopes can either be comma-separated or space-separated.")
 	flag.StringVar(&cfg.file, "file", "", "The path to the file in which to write the retrieved token.")
 	flag.StringVar(&cfg.tempFile, "temp-file", "", "The path to a temporary file to use for atomically update the token file. If left empty, \".tmp\" will be suffixed to the token file.")
 	rawURL := flag.String("url", "", "The target URL to which to proxy requests. All requests will have the acces token in the Authorization HTTP header.(DEPRECATED: Use -upstream.url instead)")

--- a/main.go
+++ b/main.go
@@ -46,6 +46,7 @@ type config struct {
 	oidc     oidcConfig
 	server   serverConfig
 	upstream upstreamConfig
+	scope    string
 }
 
 type upstreamConfig struct {
@@ -82,6 +83,7 @@ func parseFlags() (*config, error) {
 	flag.StringVar(&cfg.oidc.audience, "oidc.audience", "", "The audience for whom the access token is intended, see https://openid.net/specs/openid-connect-core-1_0.html#IDToken.")
 	flag.StringVar(&cfg.oidc.username, "oidc.username", "", "The username to use for OIDC authentication. If both username and password are set then grant_type is set to password.")
 	flag.StringVar(&cfg.oidc.password, "oidc.password", "", "The password to use for OIDC authentication. If both username and password are set then grant_type is set to password.")
+	flag.StringVar(&cfg.scope, "scope", "", "The scope to be included in the payload data of the token.")
 	flag.StringVar(&cfg.file, "file", "", "The path to the file in which to write the retrieved token.")
 	flag.StringVar(&cfg.tempFile, "temp-file", "", "The path to a temporary file to use for atomically update the token file. If left empty, \".tmp\" will be suffixed to the token file.")
 	rawURL := flag.String("url", "", "The target URL to which to proxy requests. All requests will have the acces token in the Authorization HTTP header.(DEPRECATED: Use -upstream.url instead)")
@@ -226,7 +228,11 @@ func main() {
 				"grant_type": []string{"password"},
 			}
 		}
-
+		if cfg.scope != "" {
+			ccc.EndpointParams = url.Values{
+				"scope": []string{cfg.scope},
+			}
+		}
 		if cfg.file != "" {
 			ctx, cancel := context.WithCancel(ctx)
 			g.Add(func() error {

--- a/main.go
+++ b/main.go
@@ -83,7 +83,7 @@ func parseFlags() (*config, error) {
 	flag.StringVar(&cfg.oidc.audience, "oidc.audience", "", "The audience for whom the access token is intended, see https://openid.net/specs/openid-connect-core-1_0.html#IDToken.")
 	flag.StringVar(&cfg.oidc.username, "oidc.username", "", "The username to use for OIDC authentication. If both username and password are set then grant_type is set to password.")
 	flag.StringVar(&cfg.oidc.password, "oidc.password", "", "The password to use for OIDC authentication. If both username and password are set then grant_type is set to password.")
-	flag.StringSliceVar(&cfg.scope, "scope", []string{""}, "The scope to be included in the payload data of the token. Scopes can either be comma-separated or space-separated.")
+	flag.StringSliceVar(&cfg.scope, "scope", []string{}, "The scope to be included in the payload data of the token. Scopes can either be comma-separated or space-separated.")
 	flag.StringVar(&cfg.file, "file", "", "The path to the file in which to write the retrieved token.")
 	flag.StringVar(&cfg.tempFile, "temp-file", "", "The path to a temporary file to use for atomically update the token file. If left empty, \".tmp\" will be suffixed to the token file.")
 	rawURL := flag.String("url", "", "The target URL to which to proxy requests. All requests will have the acces token in the Authorization HTTP header.(DEPRECATED: Use -upstream.url instead)")


### PR DESCRIPTION
We've come across an observatorium instance that needs to have a token including `scope` in the payload, or else it fails to authenticate.

Verified change by including `--scope="openid offline_access --file="token.out"` and verifying the "token.out" file contains a jwt.  When decoded, the payload data includes:

```
  "scope": "openid offline_access",
```
